### PR TITLE
cropperが画面遷移時にロードされない問題を修正

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,8 +8,6 @@ gem 'rails', '4.2.4'
 gem 'coffee-rails', '~> 4.1.0'
 # jQuery使う
 gem 'jquery-rails'
-# ページ遷移をajax的にしてくれるやつだった気がする
-gem 'turbolinks'
 # Jsパッケージの管理
 gem 'bower-rails', '~> 0.10.0'
 # Sassを使えるようにする

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -307,8 +307,6 @@ GEM
     thor (0.19.1)
     thread_safe (0.3.5)
     tilt (1.4.1)
-    turbolinks (2.5.3)
-      coffee-rails
     tzinfo (1.2.2)
       thread_safe (~> 0.1)
     uglifier (2.7.2)
@@ -368,7 +366,6 @@ DEPENDENCIES
   sorcery (~> 0.9.1)
   spring
   spring-commands-rspec
-  turbolinks
   uglifier (>= 1.3.0)
   unicorn
   web-console (~> 2.0)

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -12,7 +12,6 @@
 //
 //= require jquery
 //= require jquery_ujs
-//= require turbolinks
 //= require cropper
 //= require jquery-validation
 //= require_tree .

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -2,8 +2,8 @@
 <html>
 <head>
   <title>MISS-SUZUKI | 鈴木さん限定のミスコン</title>
-  <%= stylesheet_link_tag    'application', media: 'all', 'data-turbolinks-track' => true %>
-  <%= javascript_include_tag 'application', 'data-turbolinks-track' => true %>
+  <%= stylesheet_link_tag    'application', media: 'all' %>
+  <%= javascript_include_tag 'application' %>
   <%= favicon_link_tag 'favicon.ico' %>
   <%= csrf_meta_tags %>
   <meta name="keywords" content="ミスコン,鈴木さん,Miss-Suzuki,青山学院大学,佐藤さん">


### PR DESCRIPTION
turbolinkを使うと$(document).readyが発火しないようなのでturbolinkをoffにした
# 参考

http://serihiro.hatenablog.com/entry/2014/08/11/234419

また
@shogo-cloud の指摘で，google analyticsもturbolinkを使うと不都合が生じる可能性があるということでoffに
