### PR TITLE
リリースは行わないrouteをRails.env.development?で除外

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,12 +12,14 @@ Rails.application.routes.draw do
   get   'policy'   => 'static_pages#policy'
 
   scope :contestants do
-    get   'group/:id'   => 'contestants#index'
     get   'entry'       => 'contestants#entry'
     get   'new'         => 'contestants#new'
     get   'thankyou'    => 'contestants#thankyou'
     get   'mypage'      => 'contestants#mypage'
     post  'create'      => 'contestants#create'
-    post  '/:id/vote'   => 'contestants#vote', as: :vote
+    if Rails.env.development?
+      get   'group/:id'   => 'contestants#index'
+      post  '/:id/vote'   => 'contestants#vote', as: :vote
+    end
   end
 end


### PR DESCRIPTION
リリースに向けて，初回リリースでは必要のないルーティングを

```
if Rails.env.development?
    ...
end
```

と書く形で除外．

local環境では見ることが出来ます．
