### PR TITLE
active_adminのjavascriptをIS_ADMIN_WEB=trueでなければ読み込まないようにした

### DIFF
--- a/app/assets/javascripts/active_admin.js.coffee
+++ b/app/assets/javascripts/active_admin.js.coffee
@@ -1,1 +1,0 @@
-#= require active_admin/base

--- a/app/assets/javascripts/active_admin.js.coffee.erb
+++ b/app/assets/javascripts/active_admin.js.coffee.erb
@@ -1,0 +1,4 @@
+# ActiveAdminのjsは管理画面の環境変数設定時のみ読み込む
+<% if ENV['IS_ADMIN_WEB'] == 'true'
+require_asset 'active_admin/base'
+end %>


### PR DESCRIPTION
通常のフロント等に影響を及ぼさないようにするため，active_adminのjsを管理画面以外では読み込まないようにした．
