### PR TITLE
rubocopを一部無視する設定を行った

### DIFF
--- a/app/uploaders/contestant_profile_image_uploader.rb
+++ b/app/uploaders/contestant_profile_image_uploader.rb
@@ -64,6 +64,8 @@ class ContestantProfileImageUploader < CarrierWave::Uploader::Base
 
   # 画像をクロップするいい方法が見つからなかったため，urlをハードコードしてクロップ
   def thumb(width = 500, height = 500)
+    # 行が長くなりすぎる為，改行を行っているのでrubocopを一部無視
+    # rubocop:disable Style/SpaceAroundOperators
     "http://res.cloudinary.com/#{Cloudinary.config.cloud_name}/"\
     + "#{file.resource_type}/#{file.storage_type}/"\
     + "c_crop,h_#{model.profile_image_crop_param_height},"\
@@ -71,5 +73,6 @@ class ContestantProfileImageUploader < CarrierWave::Uploader::Base
     + "x_#{model.profile_image_crop_param_x},"\
     + "y_#{model.profile_image_crop_param_y}/"\
     + "c_fill,w_#{width},h_#{height}/v#{file.version}/#{file.filename}"
+    # rubocop:enable all
   end
 end


### PR DESCRIPTION
CloudinaryのURLを生成する際に，行が長くなりすぎるため改行しているが，それをrubocopに指摘されているため，無視する設定を行った．

こうしないと，一行で書く羽目になって逆に見難い

``` ruby
"http://res.cloudinary.com/#{Cloudinary.config.cloud_name}/"\
    + "#{file.resource_type}/#{file.storage_type}/"\
    + "c_crop,h_#{model.profile_image_crop_param_height},"\
    + "w_#{model.profile_image_crop_param_width},"\
    + "x_#{model.profile_image_crop_param_x},"\
    + "y_#{model.profile_image_crop_param_y}/"\
    + "c_fill,w_#{width},h_#{height}/v#{file.version}/#{file.filename}"
```
