### PR TITLE
新インフラ環境へslack通知のリンク先を変更

### DIFF
--- a/lib/tasks/contestant.rake
+++ b/lib/tasks/contestant.rake
@@ -36,7 +36,7 @@ namespace :contestant do
     contestants.each do |contestant|
       attachment = {
         fallback: "新しい応募者が現れた!",
-        pretext: "新しい応募者が現れた！: <http://27.133.130.98/miss-suzuki/admin/contestant_profiles/#{contestant.id}|link>",
+        pretext: "新しい応募者が現れた！: <http://59.106.216.27/miss-suzuki/admin/contestant_profiles/#{contestant.id}|link>",
         color: "#F6546A",
         fields: get_fields(contestant),
         thumb_url: contestant.profile_image.thumb


### PR DESCRIPTION
slackの新しい出場者通知のリンクが，旧インフラ構成に向いていたので修正
