### PR TITLE
プレ公開のユーザ画像のalt属性を名前に変更

### DIFF
--- a/app/views/static_pages/index.html.erb
+++ b/app/views/static_pages/index.html.erb
@@ -15,7 +15,7 @@
         <% @contestants.each do |contestant| %>
           <div class="<%= div_contestant_class(@contestants, contestant) %>">
             <div class="picture">
-              <%= image_tag contestant.profile.profile_image.thumb_with_blur(300, 300) %>
+              <%= image_tag contestant.profile.profile_image.thumb_with_blur(300, 300), alt: contestant.profile.name %>
             </div>
             <div class="profile">
               <p class="furigana"><%= contestant.profile.hurigana %></p>


### PR DESCRIPTION
- スマホ等でトップのロードに時間がかかると，従来の場合ファイル名が見えていた．
  - 意味不明の文字列が見えるのでヨクナイ．
  - そこで，とりあえずユーザの名前を表示するようにした
