### PR TITLE
新着応募者のトリガーをContestantProfileのcountからidベースに変更

### DIFF
--- a/lib/tasks/contestant.rake
+++ b/lib/tasks/contestant.rake
@@ -1,7 +1,7 @@
 namespace :contestant do
   desc "Check new Contestant and notify"
   task check_new: :environment do
-    prev_last_id_file_path = Rails.root +  "tmp/prev_last_contestant_id"
+    prev_last_id_file_path = Rails.root + "tmp/prev_last_contestant_id"
     prev_last_id = 0
     begin
       prev_last_id = File.read(prev_last_id_file_path).to_i


### PR DESCRIPTION
# 前提

現在，応募者の総数が増えたらslackへnotificationを流すようにしていたが，応募者のエントリを削除すると通知が正常に行われない問題があった．
# 対応

応募者のidベースでnotificationを実行するようにした
