### PR TITLE
以降の応募者をgroup 2に設定

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -1,7 +1,7 @@
 user_type:
   normal: 1
   contestant: 2
-current_group_id: 1
+current_group_id: 2
 contestant:
   preopen_count: 3 # プレオープンで公開する参加者の数
   default_blur: 500


### PR DESCRIPTION
GroupIdの更新を行った．

以降の応募者は自動的にgroup 2に設定されます．
