### PR TITLE
画像のアップロードをバックグラウンドで行うように

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -30,6 +30,8 @@ gem 'rails-i18n'
 gem 'carrierwave'
 # 画像アップロード時にクロップするgem
 gem 'carrierwave-crop'
+# carrierwaveのアップロードをバックグラウンドで行うgem
+gem 'carrierwave_backgrounder'
 # Cloudinaryとの連携用
 gem 'cloudinary'
 # アプリケーションサーバ

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -113,6 +113,8 @@ GEM
       carrierwave (>= 0.8.0, < 0.11.0)
       jquery-rails
       rails (>= 3.2)
+    carrierwave_backgrounder (0.4.2)
+      carrierwave (~> 0.5)
     celluloid (0.17.2)
       celluloid-essentials
       celluloid-extras
@@ -477,6 +479,7 @@ DEPENDENCIES
   capybara
   carrierwave
   carrierwave-crop
+  carrierwave_backgrounder
   cloudinary
   coffee-rails (~> 4.1.0)
   compass-rails

--- a/app/models/contestant_profile.rb
+++ b/app/models/contestant_profile.rb
@@ -2,6 +2,7 @@ class ContestantProfile < ActiveRecord::Base
   belongs_to :user
 
   mount_uploader :profile_image, ContestantProfileImageUploader
+  store_in_background :profile_image
 
   # バリデーション
   validates :group_id, presence: true, inclusion: { in: 1..3 }

--- a/app/uploaders/contestant_profile_image_uploader.rb
+++ b/app/uploaders/contestant_profile_image_uploader.rb
@@ -4,6 +4,7 @@ class ContestantProfileImageUploader < CarrierWave::Uploader::Base
   # Include RMagick or MiniMagick support:
   # include CarrierWave::RMagick
   # include CarrierWave::MiniMagick
+  include ::CarrierWave::Backgrounder::Delay
   include Cloudinary::CarrierWave
 
   # Choose what kind of storage to use for this uploader:

--- a/config/initializers/carrierwave_backgrounder.rb
+++ b/config/initializers/carrierwave_backgrounder.rb
@@ -1,0 +1,3 @@
+CarrierWave::Backgrounder.configure do |c|
+  c.backend :sidekiq, queue: :carrierwave
+end

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -4,6 +4,7 @@
 :queues:
   - default
   - mailers
+  - carrierwave
 :daemon: true
 development:
   :daemon: false

--- a/db/migrate/20151027134914_add_profile_image_tmp_to_contestant_profiles.rb
+++ b/db/migrate/20151027134914_add_profile_image_tmp_to_contestant_profiles.rb
@@ -1,0 +1,7 @@
+class AddProfileImageTmpToContestantProfiles < ActiveRecord::Migration
+  def change
+    add_column :contestant_profiles, :profile_image_tmp, :string
+    # carrierwave_backgrounderによる，一時的なnullを許すため
+    change_column :contestant_profiles, :profile_image, :string, null: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20151024150258) do
+ActiveRecord::Schema.define(version: 20151027134914) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -54,7 +54,7 @@ ActiveRecord::Schema.define(version: 20151024150258) do
     t.integer  "group_id",                                        null: false
     t.string   "name",                                            null: false
     t.string   "hurigana",                                        null: false
-    t.string   "profile_image",                                   null: false
+    t.string   "profile_image"
     t.string   "age"
     t.string   "height",                                          null: false
     t.string   "come_from",                                       null: false
@@ -78,6 +78,7 @@ ActiveRecord::Schema.define(version: 20151024150258) do
     t.string   "profile_image_crop_param_extra",  default: "",    null: false
     t.integer  "profile_image_blur_param",        default: 0,     null: false
     t.integer  "status",                          default: 0,     null: false
+    t.string   "profile_image_tmp"
   end
 
   add_index "contestant_profiles", ["user_id"], name: "index_contestant_profiles_on_user_id", using: :btree


### PR DESCRIPTION
# 内容

出場者の応募時に，画像のアップロードに時間がかかるため，送信完了まで３秒ぐらいかかっていた．

ユーザ=====>俺らのサーバ=====>Cloudinary

の順で画像を転送するが，Cloudinaryにアップロードし終わるまで画面遷移が行われなかった．

今回は，俺らのサーバに画像が到着した時点でユーザにはレスポンスを返却し，Cloudinaryへのアップロードはバックグラウンドで行うようにすることで，ユーザへのレスポンス速度を向上させることができる．
