### PR TITLE
	公開グループを制限する処理を追加

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -16,4 +16,8 @@ class ApplicationController < ActionController::Base
       send(Config.not_authenticated_action)
     end
   end
+
+  def not_found
+    raise ActionController::RoutingError.new('404 Not Found')
+  end
 end

--- a/app/controllers/contestants_controller.rb
+++ b/app/controllers/contestants_controller.rb
@@ -3,7 +3,11 @@ class ContestantsController < ApplicationController
   before_filter :require_contestant_login, only: [:new_interview_answer, :create_interview_answer, :my_own_page]
 
   def index
-    @contestant = Array.split3(Contestant.approved.nth_group(params[:id]).shuffle)
+    if params[:id].to_i <= Settings.current_open_group_id
+      @contestant = Array.split3(Contestant.approved.nth_group(params[:id]).shuffle)
+    else
+      not_found
+    end
   end
 
   def new

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -6,6 +6,7 @@ sex:
   female: 2
   unknown: 3
 current_group_id: 2
+current_open_group_id: 1 # 現在公開中のグループID最大値
 contestant:
   preopen_count: 3 # プレオープンで公開する参加者の数
   default_blur: 500


### PR DESCRIPTION
`contestants/group/2`とやると，第二グループも見えてしまったので制限

`config/settings.yml`で，`current_open_group_id: 1`を修正することで公開グループを変更できる
