### PR TITLE
Slackの通知先がおかしい問題を修正

### DIFF
--- a/lib/tasks/contestant.rake
+++ b/lib/tasks/contestant.rake
@@ -13,7 +13,7 @@ namespace :contestant do
     new_contestants = ContestantProfile.where("id > ?", prev_last_id)
     if new_contestants.present?
       last_id = ContestantProfile.last.id
-      notify_to_slack(new_contestant_notify_body(new_contestants))
+      notify_to_slack_for_new_contestant(new_contestant_notify_body(new_contestants))
       File.write(prev_last_id_file_path, last_id)
     end
   end
@@ -35,7 +35,7 @@ namespace :contestant do
     end
   end
 
-  def notify_to_slack(body_json)
+  def notify_to_slack_for_new_contestant(body_json)
     api_url = 'https://hooks.slack.com/services/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'
     uri = URI.parse(api_url)
     https = Net::HTTP.new(uri.host, uri.port)

--- a/lib/tasks/report.rake
+++ b/lib/tasks/report.rake
@@ -1,8 +1,8 @@
 namespace :report do
   desc "Report yesterday's vote count to slack"
   task check_yesterdays_vote_count: :environment do
-    notify_to_slack(vote_count_notify_body)
-    notify_to_slack(user_count_notify_body)
+    notify_to_slack_for_report(vote_count_notify_body)
+    notify_to_slack_for_report(user_count_notify_body)
   end
 
   def vote_count_notify_body
@@ -54,7 +54,7 @@ namespace :report do
     body.to_json
   end
 
-  def notify_to_slack(body_json)
+  def notify_to_slack_for_report(body_json)
     api_url = 'https://hooks.slack.com/services/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'
     uri = URI.parse(api_url)
     https = Net::HTTP.new(uri.host, uri.port)
@@ -65,5 +65,4 @@ namespace :report do
     req.body = body_json
     https.request(req)
   end
-
 end


### PR DESCRIPTION
rakeタスクはディレクトリ内で名前空間が同じようなので，メソッド名を変更
