### PR TITLE
デプロイ先のshared pathにpublic/uploadsを追加

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -24,7 +24,7 @@ set :log_level, :debug
 # set :linked_files, %w{config/database.yml}
 
 # Default value for linked_dirs is []
-set :linked_dirs, %w(bin log tmp/pids tmp/cache tmp/sockets vendor/bundle public/system)
+set :linked_dirs, %w(bin log tmp/pids tmp/cache tmp/sockets vendor/bundle public/system public/uploads)
 
 # 保存するリビジョン数
 set :keep_releases, 5


### PR DESCRIPTION
Unicornの再起動に失敗したり，その他諸々の理由でリロードがうまくいかない場合，public/uploadsのディレクトリがUnicornとSidekiqで不整合が生じる

そこで，全てのリビジョンでpublic/uploadsは同じディレクトリを使用するように変更
