### PR TITLE
Contestantのpartialをキャッシュするように変更

### DIFF
--- a/app/views/contestants/_contestant.html.erb
+++ b/app/views/contestants/_contestant.html.erb
@@ -1,3 +1,4 @@
+<% cache contestant.profile do %>
 <div id='contestant-<%= contestant.id %>' class="contestant">
   <div class="vote_system">
     <%= link_to (image_tag 'kawaii.png', width: 80), contestant_vote_path(contestant_id: contestant.id), method: :post, params: { group_id: contestant.profile.group_id } %>
@@ -25,3 +26,4 @@
     <textarea readonly name="comment"><%= contestant.profile.comment %></textarea>
   </div>
 </div>
+<% end %>


### PR DESCRIPTION
ContestantのPartialをキャシュして，レンダリング速度を上げることを試みる．

partial内ではほぼ`contestant.profile` の情報だけを使っているので，`contestant.profile` をキャッシュキーに設定した．
