### PR TITLE
disable image caching in nginx.

### DIFF
--- a/app/uploaders/ads_uploader.rb
+++ b/app/uploaders/ads_uploader.rb
@@ -21,6 +21,9 @@ class AdsUploader < CarrierWave::Uploader::Base
   # 画像リクエスト先サーバのホスト名を返す
   def img_server_host_name
     # Production時のみ，プロキシを介すようにする
-    Rails.env.production? ? 'miss-suzuki.com' : 'res.cloudinary.com'
+    # Rails.env.production? ? 'miss-suzuki.com' : 'res.cloudinary.com'
+    # Herokuに移すので，Cloudinaryへアクセスするようにした 
+    'res.cloudinary.com'
+
   end
 end

--- a/app/uploaders/contestant_profile_image_uploader.rb
+++ b/app/uploaders/contestant_profile_image_uploader.rb
@@ -115,6 +115,8 @@ class ContestantProfileImageUploader < CarrierWave::Uploader::Base
   # 画像リクエスト先サーバのホスト名を返す
   def img_server_host_name
     # Production時のみ，プロキシを介すようにする
-    Rails.env.production? ? 'miss-suzuki.com' : 'res.cloudinary.com'
+    # Rails.env.production? ? 'miss-suzuki.com' : 'res.cloudinary.com'
+    # Herokuに移すので，Cloudinaryへアクセスするようにした 
+    'res.cloudinary.com'
   end
 end


### PR DESCRIPTION
Herokuに移すので，さくらで作ったキャッシュサーバが使えなくなります．

それに合わせてアクセス先をcloudinaryに戻した